### PR TITLE
Remove the use of smartmatch operators

### DIFF
--- a/QohA/Files.pm
+++ b/QohA/Files.pm
@@ -44,23 +44,18 @@ sub filter {
 
     for my $type ( @$file_types ) {
         for my $f ( @{$self->files} ) {
-            given ( $type ) {
-                when (/perl/) {
-                    push @wanted_files, $f
-                        if ref $f eq 'QohA::File::Perl';
-                }
-                when (/xml/) {
-                    push @wanted_files, $f
-                        if ref $f eq 'QohA::File::XML';
-                }
-                when (/tt/) {
-                    push @wanted_files, $f
-                        if ref $f eq 'QohA::File::Template';
-                }
-                when (/yaml/) {
-                    push @wanted_files, $f
-                        if ref $f eq 'QohA::File::YAML';
-                }
+            if ( $type =~ /perl/ ) {
+                push @wanted_files, $f
+                    if ref $f eq 'QohA::File::Perl';
+            } elsif ( $type =~ /xml/) {
+                push @wanted_files, $f
+                    if ref $f eq 'QohA::File::XML';
+            } elsif ( $type =~ /tt/) {
+                push @wanted_files, $f
+                    if ref $f eq 'QohA::File::Template';
+            } elsif ( $type =~ /yaml/) {
+                push @wanted_files, $f
+                    if ref $f eq 'QohA::File::YAML';
             }
         }
     }

--- a/QohA/Report.pm
+++ b/QohA/Report.pm
@@ -62,7 +62,7 @@ sub to_string {
         if ( @diff ) {
             for my $d ( @diff ) {
                 next unless $d;  # if $d eq "" FIXME
-                next if $d =~ /^\d$/ and $d ~~ 1; # if $d == 1  We have to bring consistency for the returns of the check* routine
+                next if $d =~ /^\d$/ and $d == 1; # if $d == 1  We have to bring consistency for the returns of the check* routine
                 push @diff_ko, $d;
             }
             if ( @diff_ko ) {
@@ -91,7 +91,7 @@ sub diff {
     my ($before, $current) = @$errors;
 
     unless ( ref $current or ref $before ) {
-        if ( "$current" ~~ "$before" ) {
+        if ( "$current" == "$before" ) {
             return;
         }
         return ($current);


### PR DESCRIPTION
The use of smartmatch operators is deprecated on Perl 5.18 and
the QA check scripts should avoid it :-D
