### PR TITLE
Use YAML::XS to test YAML files instead of YAML

### DIFF
--- a/QohA/File/YAML.pm
+++ b/QohA/File/YAML.pm
@@ -2,7 +2,7 @@ package QohA::File::YAML;
 
 use Modern::Perl;
 use Moo;
-use YAML;
+use YAML::XS;
 
 use QohA::Report;
 extends 'QohA::File';
@@ -23,7 +23,7 @@ sub run_checks {
 sub check_parse_yaml {
     my ($self) = @_;
     return 0 unless -e $self->path;
-    eval { YAML::LoadFile($self->abspath); };
+    eval { YAML::XS::LoadFile($self->abspath); };
     return 0 unless $@;
 
     my @r;


### PR DESCRIPTION
YAML is being deprecated and moved to YAML::Old, and only supports YAML 1.0.
YAML::XS supports YAML 1.1, as does Mojolicious::Plugin::OpenAPI.

It makes sense to use YAML::XS for checking our YAML files instead of YAML::Old